### PR TITLE
Fixed #7: Docker-based development of Rig.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.7-alpine
+
+RUN apk add --no-cache \
+  ca-certificates \
+  git \
+  gcc \
+  musl-dev \
+  && go get github.com/tools/godep \
+  && go get github.com/mitchellh/gox

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Rig - Outrigger CLI
 
+> A CLI for managing the Outrigger container-driven development stack.
+
+See the [documentation for more details](http://docs.outrigger.sh).
+
 Use this readme when you want to develop the Outrigger CLI.
 
 Setup
@@ -68,6 +72,19 @@ NOTE: the `-cgo` in the above command is only relevant for building on OSX as th
 to use the OSX DNS Resolver instead of the built in Go resolver. This is needed in order to resolve DNS names
 that end in things like *.vm*  Using `-cgo` for Linux and Windows architectures will result in a failed build.
 
+Developing Rig with Docker [Experimental]
+-----------------------------------------
+
+You can use the Docker integration within this repository to facilitate development in lieu of setting up a
+local golang environment. Using docker-compose, run the following commands:
+
+```bash
+docker-compose run --rm install
+docker-compose run --rm build
+```
+
+This will produce a working OSX binary with partially limited functionality at `build/darwin/rig`.
+
 Deploy to Homebrew
 ------------------
 
@@ -81,8 +98,3 @@ perform the following operations.
  - Prepare a new `brew` version via `brew-publish.sh`
     - Part of this will write a new formula into homebrew-outrigger
  - Commit & push the updated formula to publish the new version
-
-
-
-
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+version: '2.1'
+
+services:
+
+  # Compile rig, dropping off a working binary in build/darwin/rig.
+  #
+  # This is not currently using -cgo, which is a requirement of rig.
+  # When -cgo is used, it leads to an error:
+  # > 1 errors occurred:
+  # > --> darwin/amd64 error: exit status 2
+  # > Stderr: # net
+  # > could not determine kind of name for C.AI_MASK
+  build:
+    extends: base
+    command: gox -osarch="Darwin/amd64" -output="build/{{.OS}}/rig"
+
+  # Install project dependencies.
+  install:
+    extends: base
+    command: godep restore -v
+
+  # Foundational service to run commands within the container.
+  base:
+    build: .
+    command: /usr/bin/env sh
+    network_mode: bridge
+    environment:
+      # /go is the default GOPATH in the Docker image.
+      GOPATH: ${OUTRIGGER_GOPATH:-/go}
+    volumes:
+      # rig dependencies are not in a tidy sub-directory, so all global golang
+      # packages are found in the same directory. This volume mount persists
+      # them in general as a sort of cache.
+      #
+      # This does not address version mismatches between packages, so is a
+      # temporary/brittle workaround.
+      - /data/golang/cache:${OUTRIGGER_GOPATH:-/go}/src
+      - .:${OUTRIGGER_GOPATH:-/go}/src/github.com/phase2/rig
+    working_dir: ${OUTRIGGER_GOPATH:-/go}/src/github.com/phase2/rig

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.1'
 
 services:
 
-  # Compile rig, dropping off a working binary in build/darwin/rig.
+  # Build rig, dropping off a working binary in build/darwin/rig.
   #
   # This is not currently using -cgo, which is a requirement of rig.
   # When -cgo is used, it leads to an error:
@@ -10,7 +10,7 @@ services:
   # > --> darwin/amd64 error: exit status 2
   # > Stderr: # net
   # > could not determine kind of name for C.AI_MASK
-  build:
+  compile:
     extends: base
     command: gox -osarch="Darwin/amd64" -output="build/{{.OS}}/rig"
 


### PR DESCRIPTION
As noted in the docker-compose file, I was unable to get the dynamic linking of -cgo compilation to work in the container. However, it does produce a working binary that can do things, I'm just not sure what it fails at right now.

`rig dashboard` and `rig start` seemed to work fine.