### PR TITLE
Handle versions more broadly to account for the new Docker versioning scheme

### DIFF
--- a/cli/commands/machine.go
+++ b/cli/commands/machine.go
@@ -23,7 +23,7 @@ type Machine struct {
 func (m *Machine) Create(driver string, cpuCount string, memSize string, diskSize string) {
 	m.out.Info.Printf("Creating a %s machine named '%s' with CPU(%s) MEM(%s) DISK(%s)...", driver, m.Name, cpuCount, memSize, diskSize)
 
-	boot2dockerUrl := "https://github.com/boot2docker/boot2docker/releases/download/v" + util.GetCurrentDockerVersion().String() + "/boot2docker.iso"
+	boot2dockerUrl := "https://github.com/boot2docker/boot2docker/releases/download/v" + util.GetRawCurrentDockerVersion() + "/boot2docker.iso"
 
 	var create *exec.Cmd
 

--- a/cli/util/util.go
+++ b/cli/util/util.go
@@ -62,10 +62,14 @@ func AskYesNo(question string) bool {
 
 }
 
-func GetCurrentDockerVersion() *version.Version {
+func GetRawCurrentDockerVersion() string {
 	output, _ := exec.Command("docker", "--version").Output()
-	re := regexp.MustCompile("Docker version ([\\d|\\.]+)")
-	versionNumber := re.FindAllStringSubmatch(string(output), -1)[0][1]
+	re := regexp.MustCompile("Docker version (.*),")
+	return re.FindAllStringSubmatch(string(output), -1)[0][1]
+}
+
+func GetCurrentDockerVersion() *version.Version {
+	versionNumber := GetRawCurrentDockerVersion()
 	return version.Must(version.NewVersion(versionNumber))
 }
 


### PR DESCRIPTION
Previously, versions were only numbers (1.13.1) and not padded.  Now, numbers are padded and with letters (17.03.0-ce).

Machine creation fails b/c it does not create the proper boot2docker URL so the ISO is not found.