### PR TITLE
Better sync detection and configuration via environmental variables

### DIFF
--- a/cli/commands/project_sync.go
+++ b/cli/commands/project_sync.go
@@ -270,7 +270,7 @@ func (cmd *ProjectSync) WaitForSyncInit(logFile string, timeoutSeconds int, sync
 
 	// The log file was not created, the sync has not started yet
 	exec.Command("rm", "-f", tempFile).Run()
-	cmd.out.Error.Fatal("Failed to detect start of initial sync! Check sync log file.")
+	cmd.out.Error.Fatal("Failed to detect start of initial sync!")
 }
 
 // Get the local Unison version to try to load a compatible unison image

--- a/cli/commands/project_sync.go
+++ b/cli/commands/project_sync.go
@@ -43,14 +43,8 @@ func (cmd *ProjectSync) Commands() []cli.Command {
 			cli.IntFlag{
 				Name:   "initial-sync-timeout",
 				Value:  60,
-				Usage:  "Maximum amount of time in seconds to allow for detection of initial sync.",
-				EnvVar: "RIG_PROJECT_INITIAL_SYNC_TIMEOUT",
-			},
-			cli.IntFlag{
-				Name:   "container-start-timeout",
-				Value:  10,
-				Usage:  "Maximum amount of time in seconds to wait for the unison container to start",
-				EnvVar: "RIG_PROJECT_CONTAINER_START_TIMEOUT",
+				Usage:  "Maximum amount of time in seconds to allow for detecting each of start of the unison container and start of initial sync",
+				EnvVar: "RIG_PROJECT_SYNC_TIMEOUT",
 			},
 			cli.IntFlag{
 				Name:   "initial-sync-wait",
@@ -104,7 +98,7 @@ func (cmd *ProjectSync) RunStart(ctx *cli.Context) error {
 		cmd.out.Error.Fatalf("Error starting sync container %s: %v", volumeName, err)
 	}
 
-	var ip = cmd.WaitForUnisonContainer(volumeName, ctx.Int("container-start-timeout"))
+	var ip = cmd.WaitForUnisonContainer(volumeName, ctx.Int("initial-sync-timeout"))
 
 	cmd.out.Info.Println("Initializing sync")
 
@@ -276,7 +270,7 @@ func (cmd *ProjectSync) WaitForSyncInit(logFile string, timeoutSeconds int, sync
 
 	// The log file was not created, the sync has not started yet
 	exec.Command("rm", "-f", tempFile).Run()
-	cmd.out.Error.Fatal("Sync container failed to start!")
+	cmd.out.Error.Fatal("Failed to detect start of initial sync! Check sync log file.")
 }
 
 // Get the local Unison version to try to load a compatible unison image

--- a/cli/commands/project_sync.go
+++ b/cli/commands/project_sync.go
@@ -46,6 +46,8 @@ func (cmd *ProjectSync) Commands() []cli.Command {
 				Usage:  "Maximum amount of time in seconds to allow for detecting each of start of the unison container and start of initial sync",
 				EnvVar: "RIG_PROJECT_SYNC_TIMEOUT",
 			},
+			// Arbitrary sleep length but anything less than 3 wasn't catching
+			// ongoing very quick file updates during a test
 			cli.IntFlag{
 				Name:   "initial-sync-wait",
 				Value:  5,
@@ -247,8 +249,6 @@ func (cmd *ProjectSync) WaitForSyncInit(logFile string, timeoutSeconds int, sync
 			exec.Command("rm", "-f", tempFile).Run()
 
 			cmd.out.Info.Print("Waiting for initial sync to finish")
-			// Arbitrary sleep length but anything less than 3 wasn't catching
-			// ongoing very quick file updates during a test
 			var statSleep = time.Duration(syncWaitSeconds) * time.Second
 			// Initialize at -2 to force at least one loop
 			var lastSize = int64(-2)

--- a/cli/commands/project_sync.go
+++ b/cli/commands/project_sync.go
@@ -41,24 +41,23 @@ func (cmd *ProjectSync) Commands() []cli.Command {
 		Description: "Volume name will be discovered in the following order: argument to this command > outrigger project config > docker-compose file > current directory name",
 		Flags: []cli.Flag{
 			cli.IntFlag{
-				Name:  "initial-sync-timeout",
-				Value: 60,
-				Usage: "Maximum amount of time in seconds to allow for detection of initial sync.",
-                EnvVar: "RIG_PROJECT_INITIAL_SYNC_TIMEOUT",
-
+				Name:   "initial-sync-timeout",
+				Value:  60,
+				Usage:  "Maximum amount of time in seconds to allow for detection of initial sync.",
+				EnvVar: "RIG_PROJECT_INITIAL_SYNC_TIMEOUT",
 			},
 			cli.IntFlag{
-				Name:  "container-start-timeout",
-				Value: 10,
-				Usage: "Maximum amount of time in seconds to wait for the unison container to start",
+				Name:   "container-start-timeout",
+				Value:  10,
+				Usage:  "Maximum amount of time in seconds to wait for the unison container to start",
 				EnvVar: "RIG_PROJECT_CONTAINER_START_TIMEOUT",
 			},
 			cli.IntFlag{
-                Name:  "initial-sync-wait",
-                Value: 5,
-                Usage: "Time in seconds to wait between checks to see if initial sync has finished.",
-                EnvVar: "RIG_PROJECT_INITIAL_SYNC_WAIT",
-            },
+				Name:   "initial-sync-wait",
+				Value:  5,
+				Usage:  "Time in seconds to wait between checks to see if initial sync has finished.",
+				EnvVar: "RIG_PROJECT_INITIAL_SYNC_WAIT",
+			},
 		},
 		Before: cmd.Before,
 		Action: cmd.RunStart,
@@ -258,15 +257,15 @@ func (cmd *ProjectSync) WaitForSyncInit(logFile string, timeoutSeconds int, sync
 			// ongoing very quick file updates during a test
 			var statSleep = time.Duration(syncWaitSeconds) * time.Second
 			// Initialize at -2 to force at least one loop
-			var lastSize = int64(-2);
+			var lastSize = int64(-2)
 			for lastSize != statInfo.Size() {
-    		    os.Stdout.WriteString(".")
-			    time.Sleep(statSleep)
-			    lastSize = statInfo.Size()
-			    if statInfo, err = os.Stat(logFile); err != nil {
-                    cmd.out.Info.Print(err.Error())
-                    lastSize = -1
-			    }
+				os.Stdout.WriteString(".")
+				time.Sleep(statSleep)
+				lastSize = statInfo.Size()
+				if statInfo, err = os.Stat(logFile); err != nil {
+					cmd.out.Info.Print(err.Error())
+					lastSize = -1
+				}
 			}
 			os.Stdout.WriteString(" done\n")
 			return

--- a/cli/commands/project_sync.go
+++ b/cli/commands/project_sync.go
@@ -245,8 +245,6 @@ func (cmd *ProjectSync) WaitForSyncInit(logFile string, timeoutSeconds int, sync
 		}
 		if statInfo, err := os.Stat(logFile); err == nil {
 			os.Stdout.WriteString(" initial sync detected\n")
-			// Remove the temp file now that we are running
-			exec.Command("rm", "-f", tempFile).Run()
 
 			cmd.out.Info.Print("Waiting for initial sync to finish")
 			var statSleep = time.Duration(syncWaitSeconds) * time.Second
@@ -262,6 +260,9 @@ func (cmd *ProjectSync) WaitForSyncInit(logFile string, timeoutSeconds int, sync
 				}
 			}
 			os.Stdout.WriteString(" done\n")
+			// Remove the temp file, waiting until after sync so spurious
+			// failure message doesn't show in log
+			exec.Command("rm", "-f", tempFile).Run()
 			return
 		} else {
 			time.Sleep(timeoutLoopSleep)


### PR DESCRIPTION
This actually waits for the unison log file to stop growing before claiming that the initial sync is done.