### PR TITLE
Demonstrate conversion of cmd.out.Error.Fatalf to cli.NewExitError [WIP]

### DIFF
--- a/cli/commands/start.go
+++ b/cli/commands/start.go
@@ -53,6 +53,12 @@ func (cmd *Start) Commands() []cli.Command {
 }
 
 func (cmd *Start) Run(c *cli.Context) error {
+	err := cmd.StartOutrigger(c)
+	notify.CommandStatus(c, err != nil)
+	return err
+}
+
+func (cmd *Start) Outrigger() error {
 	if runtime.GOOS == "linux" {
 		cmd.out.Info.Println("Linux users should use Docker natively for best performance.")
 		cmd.out.Info.Println("Please ensure your local Docker setup is compatible with Outrigger.")
@@ -63,7 +69,7 @@ func (cmd *Start) Run(c *cli.Context) error {
 		cmd.out.Verbose.Println("Pre-flight check...")
 
 		if err := exec.Command("grep", "-qE", "'^\"?/Users/'", "/etc/exports").Run(); err == nil {
-			cmd.out.Error.Fatal("Vagrant NFS mount found. Please remove any non-Outrigger mounts that begin with /Users from your /etc/exports file")
+			return cli.NewExitError("Vagrant NFS mount found. Please remove any non-Outrigger mounts that begin with /Users from your /etc/exports file", 1)
 		}
 
 		cmd.out.Verbose.Println("Resetting Docker environment variables...")


### PR DESCRIPTION
cmd.out.Error.Fatalf is the Drupal equivalent to die() instead of drupal_exit(). cli.NewExitError() is the framework approach to telling the framework to bail with that error code and message as soon as it's ready.

This will help enable notifications as a practical benefit. In the notifications PR of #70, the premise is that we configure our command callbacks to be our own "controller", and that controller can intercept these returned errors and take actions before returning the error to be handled by the framework proper.

If greenlit, I will expand this branch to include most instances of the Fatalf pattern, as we don't have many (if any) cases where immediately halting the program is essential.