### PR TITLE
Output script steps in help message.

### DIFF
--- a/cli/commands/project.go
+++ b/cli/commands/project.go
@@ -68,6 +68,8 @@ func (cmd *Project) GetScriptsAsSubcommands(otherSubcommands []cli.Command) []cl
 				command.Aliases = []string{script.Alias}
 			}
 
+			command.Description = command.Description + cmd.ScriptRunHelp(script)
+
 			commands = append(commands, command)
 		}
 	}
@@ -134,4 +136,12 @@ func (cmd *Project) addCommandPath() {
 		path := os.Getenv("PATH")
 		os.Setenv("PATH", fmt.Sprintf("%s%c%s", binDir, os.PathListSeparator, path))
 	}
+}
+
+// Generate help details based on script configuration.
+func (cmd *Project) ScriptRunHelp(script *ProjectScript) string {
+	help := fmt.Sprintf("\n\nSCRIPT STEPS:\n\t- ")
+	help = help + strings.Join(script.Run, "\n\t- ") + " [args...]\n"
+
+	return help
 }


### PR DESCRIPTION
In the interest of hitting folks over the head with what rig project scripts are doing, and hopefully provide further entries to going "deeper" into the system, let's output the script steps directly in the help.

This changes adds the new SCRIPT STEPS section.

<img width="781" alt="4__thanks_for_flying_vim__zsh_" src="https://user-images.githubusercontent.com/283489/31421042-f5c7f912-adf9-11e7-83e9-f2774d8585b4.png">
