### PR TITLE
Success/error refactoring

### DIFF
--- a/cli/commands/command.go
+++ b/cli/commands/command.go
@@ -28,7 +28,9 @@ func (cmd *BaseCommand) Before(c *cli.Context) error {
 
 func (cmd *BaseCommand) Success(message string) error {
 	//notify.CommandSuccess(message);
-	cmd.out.Info.Println(message)
+	if message != "" {
+		cmd.out.Info.Println(message)
+	}
 	return nil
 }
 

--- a/cli/commands/command.go
+++ b/cli/commands/command.go
@@ -2,9 +2,10 @@ package commands
 
 import (
 	"flag"
+	"fmt"
+
 	"github.com/phase2/rig/cli/util"
 	"github.com/urfave/cli"
-	"fmt"
 )
 
 type RigCommand interface {

--- a/cli/commands/command.go
+++ b/cli/commands/command.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"github.com/phase2/rig/cli/util"
 	"github.com/urfave/cli"
+	"fmt"
 )
 
 type RigCommand interface {
@@ -27,16 +28,14 @@ func (cmd *BaseCommand) Before(c *cli.Context) error {
 }
 
 func (cmd *BaseCommand) Success(message string) error {
-	//notify.CommandSuccess(message);
 	if message != "" {
 		cmd.out.Info.Println(message)
 	}
 	return nil
 }
 
-func (cmd *BaseCommand) Error(message string, exitCode int) error {
-	//notify.CommandError(message);
-	return cli.NewExitError(message, exitCode)
+func (cmd *BaseCommand) Error(message string, errorName string, exitCode int) error {
+	return cli.NewExitError(fmt.Sprintf("ERROR: %s [%s] (%d)", message, errorName, exitCode), exitCode)
 }
 
 func (cmd *BaseCommand) NewContext(name string, flags []cli.Flag, parent *cli.Context) *cli.Context {

--- a/cli/commands/command.go
+++ b/cli/commands/command.go
@@ -26,6 +26,17 @@ func (cmd *BaseCommand) Before(c *cli.Context) error {
 	return nil
 }
 
+func (cmd *BaseCommand) Success(message string) error {
+	//notify.CommandSuccess(message);
+	cmd.out.Info.Println(message)
+	return nil
+}
+
+func (cmd *BaseCommand) Error(message string, exitCode int) error {
+	//notify.CommandError(message);
+	return cli.NewExitError(message, exitCode)
+}
+
 func (cmd *BaseCommand) NewContext(name string, flags []cli.Flag, parent *cli.Context) *cli.Context {
 	flagSet := flag.NewFlagSet(name, flag.ContinueOnError)
 	for _, f := range flags {

--- a/cli/commands/config.go
+++ b/cli/commands/config.go
@@ -48,7 +48,7 @@ func (cmd *Config) Run(c *cli.Context) error {
 			os.Stdout.Write(output)
 		}
 	} else {
-		return cmd.Error(fmt.Sprintf("No machine named '%s' exists.", cmd.machine.Name), 11)
+		return cmd.Error(fmt.Sprintf("No machine named '%s' exists.", cmd.machine.Name), "MACHINE-NOT-FOUND", 12)
 	}
 
 	return cmd.Success("")

--- a/cli/commands/config.go
+++ b/cli/commands/config.go
@@ -48,8 +48,8 @@ func (cmd *Config) Run(c *cli.Context) error {
 			os.Stdout.Write(output)
 		}
 	} else {
-		cmd.out.Error.Fatalf("No machine named '%s' exists.", cmd.machine.Name)
+		return cmd.Error(fmt.Sprintf("No machine named '%s' exists.", cmd.machine.Name), 11)
 	}
 
-	return nil
+	return cmd.Success("")
 }

--- a/cli/commands/dashboard.go
+++ b/cli/commands/dashboard.go
@@ -29,7 +29,7 @@ func (cmd *Dashboard) Run(ctx *cli.Context) error {
 		cmd.out.Info.Println("Launching Dashboard")
 		cmd.LaunchDashboard(cmd.machine)
 	} else {
-		cmd.out.Error.Fatalf("Machine '%s' is not running.", cmd.machine.Name)
+		return cmd.Error(fmt.Sprintf("Machine '%s' is not running.", cmd.machine.Name), 11)
 	}
 
 	return nil

--- a/cli/commands/dashboard.go
+++ b/cli/commands/dashboard.go
@@ -29,10 +29,10 @@ func (cmd *Dashboard) Run(ctx *cli.Context) error {
 		cmd.out.Info.Println("Launching Dashboard")
 		cmd.LaunchDashboard(cmd.machine)
 	} else {
-		return cmd.Error(fmt.Sprintf("Machine '%s' is not running.", cmd.machine.Name), 11)
+		return cmd.Error(fmt.Sprintf("Machine '%s' is not running.", cmd.machine.Name), "MACHINE-STOPPED", 12)
 	}
 
-	return nil
+	return cmd.Success("")
 }
 
 func (cmd *Dashboard) LaunchDashboard(machine Machine) {

--- a/cli/commands/data_backup.go
+++ b/cli/commands/data_backup.go
@@ -48,11 +48,11 @@ func (cmd *DataBackup) Run(c *cli.Context) error {
 		cmd.out.Info.Printf("Creating backup directory: %s...", backupDir)
 		if mkdirErr := exec.Command("mkdir", "-p", backupDir).Run(); mkdirErr != nil {
 			cmd.out.Error.Println(mkdirErr)
-			cmd.out.Error.Fatalf("Could not create backup directory %s", backupDir)
+			return cmd.Error(fmt.Sprintf("Could not create backup directory %s", backupDir), 12)
 		}
 	} else if _, err := os.Stat(backupFile); err == nil {
 		// If the backup dir already exists, make sure the backup file does not exist.
-		cmd.out.Error.Fatalf("Backup archive %s already exists.", backupFile)
+		return cmd.Error(fmt.Sprintf("Backup archive %s already exists.", backupFile), 13)
 	}
 
 	cmd.out.Info.Printf("Backing up %s on '%s' to %s...", dataDir, cmd.machine.Name, backupFile)
@@ -68,8 +68,8 @@ func (cmd *DataBackup) Run(c *cli.Context) error {
 	color.Unset()
 
 	if err != nil {
-		cmd.out.Warning.Println("There may have been problems. See above for any errors")
+		return cmd.Error(err.Error(), 14)
 	}
 
-	return nil
+	return cmd.Success("Data Backup completed with no errors")
 }

--- a/cli/commands/data_backup.go
+++ b/cli/commands/data_backup.go
@@ -48,11 +48,11 @@ func (cmd *DataBackup) Run(c *cli.Context) error {
 		cmd.out.Info.Printf("Creating backup directory: %s...", backupDir)
 		if mkdirErr := exec.Command("mkdir", "-p", backupDir).Run(); mkdirErr != nil {
 			cmd.out.Error.Println(mkdirErr)
-			return cmd.Error(fmt.Sprintf("Could not create backup directory %s", backupDir), 12)
+			return cmd.Error(fmt.Sprintf("Could not create backup directory %s", backupDir), "BACKUP-DIR-CREATE-FAILED", 12)
 		}
 	} else if _, err := os.Stat(backupFile); err == nil {
 		// If the backup dir already exists, make sure the backup file does not exist.
-		return cmd.Error(fmt.Sprintf("Backup archive %s already exists.", backupFile), 13)
+		return cmd.Error(fmt.Sprintf("Backup archive %s already exists.", backupFile), "BACKUP-ARCHIVE-EXISTS", 12)
 	}
 
 	cmd.out.Info.Printf("Backing up %s on '%s' to %s...", dataDir, cmd.machine.Name, backupFile)
@@ -68,7 +68,7 @@ func (cmd *DataBackup) Run(c *cli.Context) error {
 	color.Unset()
 
 	if err != nil {
-		return cmd.Error(err.Error(), 14)
+		return cmd.Error(err.Error(), "COMMAND-ERROR", 13)
 	}
 
 	return cmd.Success("Data Backup completed with no errors")

--- a/cli/commands/data_restore.go
+++ b/cli/commands/data_restore.go
@@ -48,7 +48,7 @@ func (cmd *DataRestore) Run(c *cli.Context) error {
 	}
 
 	if _, err := os.Stat(backupFile); err != nil {
-		cmd.out.Error.Fatalf("Backup archive %s doesn't exists.", backupFile)
+		return cmd.Error(fmt.Sprintf("Backup archive %s doesn't exists.", backupFile), 15)
 	}
 
 	cmd.out.Info.Printf("Restoring %s to %s on '%s'...", backupFile, dataDir, cmd.machine.Name)
@@ -64,8 +64,8 @@ func (cmd *DataRestore) Run(c *cli.Context) error {
 	color.Unset()
 
 	if err != nil {
-		cmd.out.Warning.Println("There may have been problems. See above for any errors")
+		return cmd.Error(err.Error(), 16)
 	}
 
-	return nil
+	return cmd.Success("Data Restore was successful")
 }

--- a/cli/commands/data_restore.go
+++ b/cli/commands/data_restore.go
@@ -48,7 +48,7 @@ func (cmd *DataRestore) Run(c *cli.Context) error {
 	}
 
 	if _, err := os.Stat(backupFile); err != nil {
-		return cmd.Error(fmt.Sprintf("Backup archive %s doesn't exists.", backupFile), 15)
+		return cmd.Error(fmt.Sprintf("Backup archive %s doesn't exists.", backupFile), "BACKUP-ARCHIVE-NOT-FOUND", 12)
 	}
 
 	cmd.out.Info.Printf("Restoring %s to %s on '%s'...", backupFile, dataDir, cmd.machine.Name)
@@ -64,7 +64,7 @@ func (cmd *DataRestore) Run(c *cli.Context) error {
 	color.Unset()
 
 	if err != nil {
-		return cmd.Error(err.Error(), 16)
+		return cmd.Error(err.Error(), "COMMAND-ERROR", 13)
 	}
 
 	return cmd.Success("Data Restore was successful")

--- a/cli/commands/dns-records.go
+++ b/cli/commands/dns-records.go
@@ -31,7 +31,7 @@ func (cmd *DnsRecords) Run(c *cli.Context) error {
 
 	records, err := cmd.LoadRecords()
 	if err != nil {
-		return cmd.Error(err.Error(), 17)
+		return cmd.Error(err.Error(), "COMMAND-ERROR", 13)
 	}
 
 	for _, record := range records {

--- a/cli/commands/dns-records.go
+++ b/cli/commands/dns-records.go
@@ -31,7 +31,7 @@ func (cmd *DnsRecords) Run(c *cli.Context) error {
 
 	records, err := cmd.LoadRecords()
 	if err != nil {
-		cmd.out.Error.Fatalln(err)
+		return cmd.Error(err.Error(), 17)
 	}
 
 	for _, record := range records {
@@ -44,7 +44,7 @@ func (cmd *DnsRecords) Run(c *cli.Context) error {
 		}
 	}
 
-	return nil
+	return cmd.Success("")
 }
 
 // Get the records from DNSDock and process/return them

--- a/cli/commands/dns.go
+++ b/cli/commands/dns.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"strings"
 
+	"fmt"
 	"github.com/phase2/rig/cli/util"
 	"github.com/urfave/cli"
 )
@@ -40,10 +41,10 @@ func (cmd *Dns) Run(c *cli.Context) error {
 		cmd.ConfigureDns(cmd.machine, c.String("nameservers"))
 		cmd.ConfigureRoutes(cmd.machine)
 	} else {
-		cmd.out.Error.Fatalf("Machine '%s' is not running.", cmd.machine.Name)
+		return cmd.Error(fmt.Sprintf("Machine '%s' is not running.", cmd.machine.Name), 11)
 	}
 
-	return nil
+	return cmd.Success("DNS Services have been started")
 }
 
 // Remove the host filter from the xhyve bridge interface

--- a/cli/commands/dns.go
+++ b/cli/commands/dns.go
@@ -41,7 +41,7 @@ func (cmd *Dns) Run(c *cli.Context) error {
 		cmd.ConfigureDns(cmd.machine, c.String("nameservers"))
 		cmd.ConfigureRoutes(cmd.machine)
 	} else {
-		return cmd.Error(fmt.Sprintf("Machine '%s' is not running.", cmd.machine.Name), 11)
+		return cmd.Error(fmt.Sprintf("Machine '%s' is not running.", cmd.machine.Name), "MACHINE-STOPPED",  12)
 	}
 
 	return cmd.Success("DNS Services have been started")

--- a/cli/commands/dns.go
+++ b/cli/commands/dns.go
@@ -41,7 +41,7 @@ func (cmd *Dns) Run(c *cli.Context) error {
 		cmd.ConfigureDns(cmd.machine, c.String("nameservers"))
 		cmd.ConfigureRoutes(cmd.machine)
 	} else {
-		return cmd.Error(fmt.Sprintf("Machine '%s' is not running.", cmd.machine.Name), "MACHINE-STOPPED",  12)
+		return cmd.Error(fmt.Sprintf("Machine '%s' is not running.", cmd.machine.Name), "MACHINE-STOPPED", 12)
 	}
 
 	return cmd.Success("DNS Services have been started")

--- a/cli/commands/kill.go
+++ b/cli/commands/kill.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"os/exec"
 
+	"fmt"
 	"github.com/phase2/rig/cli/util"
 	"github.com/urfave/cli"
 )
@@ -24,12 +25,14 @@ func (cmd *Kill) Commands() []cli.Command {
 
 func (cmd *Kill) Run(c *cli.Context) error {
 	if !cmd.machine.Exists() {
-		cmd.out.Error.Fatalf("No machine named '%s' exists.", cmd.machine.Name)
+		return cmd.Error(fmt.Sprintf("No machine named '%s' exists.", cmd.machine.Name), 11)
 	}
 
 	// First stop it (and cleanup)
 	stop := Stop{BaseCommand{machine: cmd.machine, out: cmd.out}}
-	stop.Run(c)
+	if err := stop.Run(c); err != nil {
+		return err
+	}
 
 	cmd.out.Info.Printf("Killing machine '%s'", cmd.machine.Name)
 	util.StreamCommand(exec.Command("docker-machine", "kill", cmd.machine.Name))
@@ -47,5 +50,5 @@ func (cmd *Kill) Run(c *cli.Context) error {
 		cmd.out.Warning.Printf("Driver not recognized: %s\n", driver)
 	}
 
-	return nil
+	return cmd.Success(fmt.Sprintf("Machine '%s' killed", cmd.machine.Name))
 }

--- a/cli/commands/kill.go
+++ b/cli/commands/kill.go
@@ -25,7 +25,7 @@ func (cmd *Kill) Commands() []cli.Command {
 
 func (cmd *Kill) Run(c *cli.Context) error {
 	if !cmd.machine.Exists() {
-		return cmd.Error(fmt.Sprintf("No machine named '%s' exists.", cmd.machine.Name), 11)
+		return cmd.Error(fmt.Sprintf("No machine named '%s' exists.", cmd.machine.Name), "MACHINE-NOT-FOUND", 12)
 	}
 
 	// First stop it (and cleanup)

--- a/cli/commands/project.go
+++ b/cli/commands/project.go
@@ -97,14 +97,13 @@ func (cmd *Project) Run(c *cli.Context) error {
 
 		cmd.out.Verbose.Printf("Executing '%s' as '%s'", key, scriptCommands)
 		if exitCode := util.PassthruCommand(shellCmd); exitCode != 0 {
-			cmd.out.Error.Printf("Error running project script '%s': %d", key, exitCode)
-			os.Exit(exitCode)
+			return cmd.Error(fmt.Sprintf("Error running project script '%s': %d", key), exitCode)
 		}
 	} else {
-		cmd.out.Error.Printf("Unrecognized script '%s'", key)
+		return cmd.Error(fmt.Sprintf("Unrecognized script '%s'", key), 19)
 	}
 
-	return nil
+	return cmd.Success("")
 }
 
 // Construct a command to execute a configured script.

--- a/cli/commands/project.go
+++ b/cli/commands/project.go
@@ -97,10 +97,10 @@ func (cmd *Project) Run(c *cli.Context) error {
 
 		cmd.out.Verbose.Printf("Executing '%s' as '%s'", key, scriptCommands)
 		if exitCode := util.PassthruCommand(shellCmd); exitCode != 0 {
-			return cmd.Error(fmt.Sprintf("Error running project script '%s': %d", key), exitCode)
+			return cmd.Error(fmt.Sprintf("Error running project script '%s': %d", key), "COMMAND-ERROR", exitCode)
 		}
 	} else {
-		return cmd.Error(fmt.Sprintf("Unrecognized script '%s'", key), 19)
+		return cmd.Error(fmt.Sprintf("Unrecognized script '%s'", key), "SCRIPT-NOT-FOUND", 12)
 	}
 
 	return cmd.Success("")

--- a/cli/commands/project_create.go
+++ b/cli/commands/project_create.go
@@ -58,7 +58,7 @@ func (cmd *ProjectCreate) Create(ctx *cli.Context) error {
 			return err
 		}
 	} else {
-		return cmd.Error(fmt.Sprintf("Machine '%s' is not running.", cmd.machine.Name), 11)
+		return cmd.Error(fmt.Sprintf("Machine '%s' is not running.", cmd.machine.Name), "MACHINE-STOPPED", 12)
 	}
 
 	return cmd.Success("")
@@ -86,7 +86,7 @@ func (cmd *ProjectCreate) RunGenerator(ctx *cli.Context, machine Machine, image 
 
 	cwd, err := os.Getwd()
 	if err != nil {
-		return cmd.Error(fmt.Sprintf("Couldn't determine current working directory: %s", err), 20)
+		return cmd.Error(fmt.Sprintf("Couldn't determine current working directory: %s", err), "WORKING-DIR-NOT-FOUND", 12)
 	}
 
 	// Keep passed in args as distinct elements or they will be treated as
@@ -104,7 +104,7 @@ func (cmd *ProjectCreate) RunGenerator(ctx *cli.Context, machine Machine, image 
 
 	shellCmd := exec.Command("docker", args...)
 	if exitCode := util.PassthruCommand(shellCmd); exitCode != 0 {
-		return cmd.Error(fmt.Sprintf("Error running generator %s %s", image, strings.Join(ctx.Args(), " ")), exitCode)
+		return cmd.Error(fmt.Sprintf("Error running generator %s %s", image, strings.Join(ctx.Args(), " ")), "COMMAND-ERROR", exitCode)
 	}
 
 	return nil

--- a/cli/commands/project_create.go
+++ b/cli/commands/project_create.go
@@ -54,12 +54,14 @@ func (cmd *ProjectCreate) Create(ctx *cli.Context) error {
 
 	if cmd.machine.IsRunning() {
 		cmd.out.Verbose.Printf("Executing container %s%s", image, argsMessage)
-		cmd.RunGenerator(ctx, cmd.machine, image)
+		if err := cmd.RunGenerator(ctx, cmd.machine, image); err != nil {
+			return err
+		}
 	} else {
-		cmd.out.Error.Fatalf("Machine '%s' is not running.", cmd.machine.Name)
+		return cmd.Error(fmt.Sprintf("Machine '%s' is not running.", cmd.machine.Name), 11)
 	}
 
-	return nil
+	return cmd.Success("")
 }
 
 func (cmd *ProjectCreate) RunGenerator(ctx *cli.Context, machine Machine, image string) error {
@@ -84,8 +86,7 @@ func (cmd *ProjectCreate) RunGenerator(ctx *cli.Context, machine Machine, image 
 
 	cwd, err := os.Getwd()
 	if err != nil {
-		cmd.out.Error.Printf("Couldn't determine current working directory: %s", err)
-		os.Exit(1)
+		return cmd.Error(fmt.Sprintf("Couldn't determine current working directory: %s", err), 20)
 	}
 
 	// Keep passed in args as distinct elements or they will be treated as
@@ -103,8 +104,7 @@ func (cmd *ProjectCreate) RunGenerator(ctx *cli.Context, machine Machine, image 
 
 	shellCmd := exec.Command("docker", args...)
 	if exitCode := util.PassthruCommand(shellCmd); exitCode != 0 {
-		cmd.out.Error.Printf("Error running generator %s %s: %d", image, strings.Join(ctx.Args(), " "), exitCode)
-		os.Exit(exitCode)
+		return cmd.Error(fmt.Sprintf("Error running generator %s %s", image, strings.Join(ctx.Args(), " ")), exitCode)
 	}
 
 	return nil

--- a/cli/commands/prune.go
+++ b/cli/commands/prune.go
@@ -23,11 +23,10 @@ func (cmd *Prune) Commands() []cli.Command {
 }
 
 func (cmd *Prune) Run(c *cli.Context) error {
-	cmd.out.Info.Println("Removing exited Docker containers...")
-	util.StreamCommand(exec.Command("bash", "-c", "docker ps -a -q -f status=exited | grep . | xargs docker rm -v"))
+	cmd.out.Info.Println("Cleaning up Docker images and containers...")
+	if exitCode := util.PassthruCommand(exec.Command("docker", "system", "prune", "--all", "--volumes")); exitCode != 0 {
+		return cmd.Error("Error pruning Docker resources.", "COMMAND-ERROR", 13)
+	}
 
-	cmd.out.Info.Println("Removing dangling Docker images...")
-	util.StreamCommand(exec.Command("bash", "-c", "docker images --no-trunc -q -f \"dangling=true\" | grep . | xargs docker rmi"))
-
-	return nil
+	return cmd.Success("")
 }

--- a/cli/commands/remove.go
+++ b/cli/commands/remove.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"fmt"
 	"github.com/phase2/rig/cli/util"
 	"github.com/urfave/cli"
 )
@@ -28,7 +29,7 @@ func (cmd *Remove) Commands() []cli.Command {
 
 func (cmd *Remove) Run(c *cli.Context) error {
 	if !cmd.machine.Exists() {
-		cmd.out.Error.Fatalf("No machine named '%s' exists.", cmd.machine.Name)
+		return cmd.Error(fmt.Sprintf("No machine named '%s' exists.", cmd.machine.Name), 11)
 	}
 
 	cmd.out.Info.Printf("Removing '%s'", cmd.machine.Name)
@@ -40,17 +41,18 @@ func (cmd *Remove) Run(c *cli.Context) error {
 		cmd.out.Warning.Println()
 
 		if !util.AskYesNo("Are you sure you want to remove '" + cmd.machine.Name + "'") {
-			cmd.out.Warning.Println("Remove was aborted")
-			return nil
+			return cmd.Success("Remove was aborted")
 		}
 	}
 
 	// Run kill first
 	kill := Kill{BaseCommand{machine: cmd.machine, out: cmd.out}}
-	kill.Run(c)
+	if err := kill.Run(c); err != nil {
+		return err
+	}
 
 	cmd.out.Info.Println("Removing the docker-machine")
 	cmd.machine.Remove()
 
-	return nil
+	return cmd.Success(fmt.Sprintf("Machine '%' removed", cmd.machine.Name))
 }

--- a/cli/commands/remove.go
+++ b/cli/commands/remove.go
@@ -29,7 +29,7 @@ func (cmd *Remove) Commands() []cli.Command {
 
 func (cmd *Remove) Run(c *cli.Context) error {
 	if !cmd.machine.Exists() {
-		return cmd.Error(fmt.Sprintf("No machine named '%s' exists.", cmd.machine.Name), 11)
+		return cmd.Error(fmt.Sprintf("No machine named '%s' exists.", cmd.machine.Name), "MACHINE-NOT-FOUND", 12)
 	}
 
 	cmd.out.Info.Printf("Removing '%s'", cmd.machine.Name)
@@ -54,5 +54,5 @@ func (cmd *Remove) Run(c *cli.Context) error {
 	cmd.out.Info.Println("Removing the docker-machine")
 	cmd.machine.Remove()
 
-	return cmd.Success(fmt.Sprintf("Machine '%' removed", cmd.machine.Name))
+	return cmd.Success(fmt.Sprintf("Machine '%s' removed", cmd.machine.Name))
 }

--- a/cli/commands/restart.go
+++ b/cli/commands/restart.go
@@ -38,7 +38,7 @@ func (cmd *Restart) Run(c *cli.Context) error {
 			return err
 		}
 	} else {
-		return cmd.Error(fmt.Sprintf("No machine named '%s' exists.", cmd.machine.Name), 11)
+		return cmd.Error(fmt.Sprintf("No machine named '%s' exists.", cmd.machine.Name), "MACHINE-NOT-FOUND", 12)
 	}
 
 	return cmd.Success(fmt.Sprintf("Machine '%s' restarted", cmd.machine.Name))

--- a/cli/commands/restart.go
+++ b/cli/commands/restart.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"time"
 
+	"fmt"
 	"github.com/urfave/cli"
 )
 
@@ -26,15 +27,19 @@ func (cmd *Restart) Run(c *cli.Context) error {
 		cmd.out.Info.Printf("Restarting machine '%s'", cmd.machine.Name)
 
 		stop := Stop{BaseCommand{machine: cmd.machine, out: cmd.out}}
-		stop.Run(c)
+		if err := stop.Run(c); err != nil {
+			return err
+		}
 
 		time.Sleep(time.Duration(5) * time.Second)
 
 		start := Start{BaseCommand{machine: cmd.machine, out: cmd.out}}
-		start.Run(c)
+		if err := start.Run(c); err != nil {
+			return err
+		}
 	} else {
-		cmd.out.Error.Fatalf("No machine named '%s' exists.", cmd.machine.Name)
+		return cmd.Error(fmt.Sprintf("No machine named '%s' exists.", cmd.machine.Name), 11)
 	}
 
-	return nil
+	return cmd.Success(fmt.Sprintf("Machine '%s' restarted", cmd.machine.Name))
 }

--- a/cli/commands/start.go
+++ b/cli/commands/start.go
@@ -63,7 +63,7 @@ func (cmd *Start) Run(c *cli.Context) error {
 		cmd.out.Verbose.Println("Pre-flight check...")
 
 		if err := exec.Command("grep", "-qE", "'^\"?/Users/'", "/etc/exports").Run(); err == nil {
-			cmd.out.Error.Fatal("Vagrant NFS mount found. Please remove any non-Outrigger mounts that begin with /Users from your /etc/exports file")
+			return cmd.Error("Vagrant NFS mount found. Please remove any non-Outrigger mounts that begin with /Users from your /etc/exports file", 10);
 		}
 
 		cmd.out.Verbose.Println("Resetting Docker environment variables...")
@@ -129,7 +129,5 @@ func (cmd *Start) Run(c *cli.Context) error {
 	dash := Dashboard{BaseCommand{machine: cmd.machine, out: cmd.out}}
 	dash.LaunchDashboard(cmd.machine)
 
-	cmd.out.Info.Println("Outrigger is ready to use")
-
-	return nil
+	return cmd.Success("Outrigger is ready to use")
 }

--- a/cli/commands/start.go
+++ b/cli/commands/start.go
@@ -63,7 +63,7 @@ func (cmd *Start) Run(c *cli.Context) error {
 		cmd.out.Verbose.Println("Pre-flight check...")
 
 		if err := exec.Command("grep", "-qE", "'^\"?/Users/'", "/etc/exports").Run(); err == nil {
-			return cmd.Error("Vagrant NFS mount found. Please remove any non-Outrigger mounts that begin with /Users from your /etc/exports file", 10)
+			return cmd.Error("Vagrant NFS mount found. Please remove any non-Outrigger mounts that begin with /Users from your /etc/exports file", "NFS-MOUNT-CONFLICT", 12)
 		}
 
 		cmd.out.Verbose.Println("Resetting Docker environment variables...")

--- a/cli/commands/start.go
+++ b/cli/commands/start.go
@@ -63,7 +63,7 @@ func (cmd *Start) Run(c *cli.Context) error {
 		cmd.out.Verbose.Println("Pre-flight check...")
 
 		if err := exec.Command("grep", "-qE", "'^\"?/Users/'", "/etc/exports").Run(); err == nil {
-			return cmd.Error("Vagrant NFS mount found. Please remove any non-Outrigger mounts that begin with /Users from your /etc/exports file", 10);
+			return cmd.Error("Vagrant NFS mount found. Please remove any non-Outrigger mounts that begin with /Users from your /etc/exports file", 10)
 		}
 
 		cmd.out.Verbose.Println("Resetting Docker environment variables...")

--- a/cli/commands/status.go
+++ b/cli/commands/status.go
@@ -26,7 +26,7 @@ func (cmd *Status) Commands() []cli.Command {
 
 func (cmd *Status) Run(c *cli.Context) error {
 	if !cmd.machine.Exists() {
-		return cmd.Error(fmt.Sprintf("No machine named '%s' exists.", cmd.machine.Name), 11)
+		return cmd.Error(fmt.Sprintf("No machine named '%s' exists.", cmd.machine.Name), "MACHINE-NOT-FOUND", 12)
 	}
 
 	if cmd.out.IsVerbose {

--- a/cli/commands/status.go
+++ b/cli/commands/status.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"os/exec"
 
+	"fmt"
 	"github.com/phase2/rig/cli/util"
 	"github.com/urfave/cli"
 	"os"
@@ -25,7 +26,7 @@ func (cmd *Status) Commands() []cli.Command {
 
 func (cmd *Status) Run(c *cli.Context) error {
 	if !cmd.machine.Exists() {
-		cmd.out.Error.Fatalf("No machine named '%s' exists.", cmd.machine.Name)
+		return cmd.Error(fmt.Sprintf("No machine named '%s' exists.", cmd.machine.Name), 11)
 	}
 
 	if cmd.out.IsVerbose {
@@ -35,5 +36,5 @@ func (cmd *Status) Run(c *cli.Context) error {
 		os.Stdout.Write(output)
 	}
 
-	return nil
+	return cmd.Success("")
 }

--- a/cli/commands/stop.go
+++ b/cli/commands/stop.go
@@ -4,6 +4,7 @@ import (
 	"os/exec"
 	"runtime"
 
+	"fmt"
 	"github.com/fatih/color"
 	"github.com/urfave/cli"
 )
@@ -38,5 +39,5 @@ func (cmd *Stop) Run(c *cli.Context) error {
 	}
 	color.Unset()
 
-	return nil
+	return cmd.Success(fmt.Sprintf("Machine '%s' stopped", cmd.machine.Name))
 }

--- a/cli/commands/upgrade.go
+++ b/cli/commands/upgrade.go
@@ -40,13 +40,13 @@ func (cmd *Upgrade) Run(c *cli.Context) error {
 	cmd.out.Info.Printf("Upgrading '%s'...", cmd.machine.Name)
 
 	if cmd.machine.GetData().Get("Driver").Get("Boot2DockerURL").MustString() == "" {
-		return cmd.Error(fmt.Sprintf("Machine '%s' was not created with a boot2docker URL. Run `docker-machine upgrade %s` directly", cmd.machine.Name, cmd.machine.Name), 17)
+		return cmd.Error(fmt.Sprintf("Machine '%s' was not created with a boot2docker URL. Run `docker-machine upgrade %s` directly", cmd.machine.Name, cmd.machine.Name), "MACHINE-CREATED-MANUALLY", 12)
 	}
 
 	currentDockerVersion := util.GetCurrentDockerVersion()
 	machineDockerVersion, err := cmd.machine.GetDockerVersion()
 	if err != nil {
-		return cmd.Error(fmt.Sprintf("Could not determine Machine Docker version. Is your machine running?. %s", err), 11)
+		return cmd.Error(fmt.Sprintf("Could not determine Machine Docker version. Is your machine running?. %s", err), "MACHINE-STOPPED", 12)
 	}
 
 	if currentDockerVersion.Equal(machineDockerVersion) {

--- a/cli/commands/upgrade.go
+++ b/cli/commands/upgrade.go
@@ -40,29 +40,31 @@ func (cmd *Upgrade) Run(c *cli.Context) error {
 	cmd.out.Info.Printf("Upgrading '%s'...", cmd.machine.Name)
 
 	if cmd.machine.GetData().Get("Driver").Get("Boot2DockerURL").MustString() == "" {
-		cmd.out.Info.Printf("Machine '%s' was not created with a boot2docker URL. Run `docker-machine upgrade %s` directly", cmd.machine.Name, cmd.machine.Name)
-		os.Exit(1)
+		return cmd.Error(fmt.Sprintf("Machine '%s' was not created with a boot2docker URL. Run `docker-machine upgrade %s` directly", cmd.machine.Name, cmd.machine.Name), 17)
 	}
 
 	currentDockerVersion := util.GetCurrentDockerVersion()
 	machineDockerVersion, err := cmd.machine.GetDockerVersion()
 	if err != nil {
-		cmd.out.Error.Fatalf("Could not determine Machine Docker version. Is your machine running?. %s", err)
+		return cmd.Error(fmt.Sprintf("Could not determine Machine Docker version. Is your machine running?. %s", err), 11)
 	}
 
 	if currentDockerVersion.Equal(machineDockerVersion) {
-		cmd.out.Info.Printf("Machine '%s' has the same Docker version (%s) as your local Docker binary (%s). There is nothing to upgrade. If you wish to upgrade you'll need to install a newer version of the Docker binary before running the upgrade command.", cmd.machine.Name, machineDockerVersion, currentDockerVersion)
-		os.Exit(1)
+		return cmd.Success(fmt.Sprintf("Machine '%s' has the same Docker version (%s) as your local Docker binary (%s). There is nothing to upgrade. If you wish to upgrade you'll need to install a newer version of the Docker binary before running the upgrade command.", cmd.machine.Name, machineDockerVersion, currentDockerVersion))
 	}
 
 	cmd.out.Info.Printf("Backing up to prepare for upgrade...")
 	backup := &DataBackup{BaseCommand{machine: cmd.machine, out: cmd.out}}
-	backup.Run(c)
+	if err := backup.Run(c); err != nil {
+		return err
+	}
 
 	remove := &Remove{BaseCommand{machine: cmd.machine, out: cmd.out}}
 	removeCtx := cmd.NewContext(remove.Commands()[0].Name, remove.Commands()[0].Flags, c)
 	cmd.SetContextFlag(removeCtx, "force", strconv.FormatBool(true))
-	remove.Run(removeCtx)
+	if err := remove.Run(removeCtx); err != nil {
+		return err
+	}
 
 	start := &Start{BaseCommand{machine: cmd.machine, out: cmd.out}}
 	startCtx := cmd.NewContext(start.Commands()[0].Name, start.Commands()[0].Flags, c)
@@ -70,14 +72,18 @@ func (cmd *Upgrade) Run(c *cli.Context) error {
 	cmd.SetContextFlag(startCtx, "cpu-count", strconv.FormatInt(int64(cmd.machine.GetCPU()), 10))
 	cmd.SetContextFlag(startCtx, "memory-size", strconv.FormatInt(int64(cmd.machine.GetMemory()), 10))
 	cmd.SetContextFlag(startCtx, "disk-size", strconv.FormatInt(int64(cmd.machine.GetDiskInGB()), 10))
-	start.Run(startCtx)
+	if err := start.Run(startCtx); err != nil {
+		return err
+	}
 
 	restore := &DataRestore{BaseCommand{machine: cmd.machine, out: cmd.out}}
 	restoreCtx := cmd.NewContext(restore.Commands()[0].Name, restore.Commands()[0].Flags, c)
 	cmd.SetContextFlag(restoreCtx, "data-dir", c.String("data-dir"))
 	backupFile := fmt.Sprintf("%s%c%s.tgz", c.String("backup-dir"), os.PathSeparator, cmd.machine.Name)
 	cmd.SetContextFlag(restoreCtx, "backup-file", backupFile)
-	restore.Run(restoreCtx)
+	if err := restore.Run(restoreCtx); err != nil {
+		return err
+	}
 
-	return nil
+	return cmd.Success(fmt.Sprintf("Upgrade of '%s' complete", cmd.machine.Name))
 }


### PR DESCRIPTION
This allows us to centrally control how things get handled for success and error. It also means we don't need to config which commands provide notifications or not b/c we can just not call those or we can make `cmd.Success` and `cmd.NotifySuccess` and `cmd.Error` and `cmd.NotifyError` and that leaves it up to each command to control if it integrates with notifications or not?