### PR TITLE
Recursively find outrigger.yml

### DIFF
--- a/cli/commands/command.go
+++ b/cli/commands/command.go
@@ -18,6 +18,8 @@ type BaseCommand struct {
 
 // Run before all commands to setup core services
 func (cmd *BaseCommand) Before(c *cli.Context) error {
+	// Re-initialize logger in case Commands() call led to a logger trigger.
+	util.LoggerInit(c.GlobalBool("verbose"))
 	cmd.out = util.Logger()
 	cmd.machine = Machine{Name: c.GlobalString("name"), out: util.Logger()}
 	return nil

--- a/cli/commands/command.go
+++ b/cli/commands/command.go
@@ -16,9 +16,10 @@ type BaseCommand struct {
 	machine Machine
 }
 
-// Run before all commands to setup core services
+// Run before all commands to setup core services.
 func (cmd *BaseCommand) Before(c *cli.Context) error {
-	// Re-initialize logger in case Commands() call led to a logger trigger.
+	// Re-initialize logger in case Commands() call led to logger usage which
+	// initialized the logger without the verbose flag if present.
 	util.LoggerInit(c.GlobalBool("verbose"))
 	cmd.out = util.Logger()
 	cmd.machine = Machine{Name: c.GlobalString("name"), out: util.Logger()}

--- a/cli/commands/project.go
+++ b/cli/commands/project.go
@@ -42,6 +42,16 @@ func (cmd *Project) Commands() []cli.Command {
 	return []cli.Command{command}
 }
 
+// Run before all commands to setup core services
+func (cmd *Project) Before(c *cli.Context) error {
+	if err := cmd.BaseCommand.Before(c); err != nil {
+		return err
+	}
+	cmd.out.Verbose.Printf("Loaded project configuration from %s", cmd.Config.Path)
+
+	return nil
+}
+
 // Processes script configuration into formal subcommands.
 func (cmd *Project) GetScriptsAsSubcommands(otherSubcommands []cli.Command) []cli.Command {
 

--- a/cli/commands/project.go
+++ b/cli/commands/project.go
@@ -42,19 +42,8 @@ func (cmd *Project) Commands() []cli.Command {
 	return []cli.Command{command}
 }
 
-// Run before all commands to setup core services
-func (cmd *Project) Before(c *cli.Context) error {
-	if err := cmd.BaseCommand.Before(c); err != nil {
-		return err
-	}
-	cmd.out.Verbose.Printf("Loaded project configuration from %s", cmd.Config.Path)
-
-	return nil
-}
-
 // Processes script configuration into formal subcommands.
 func (cmd *Project) GetScriptsAsSubcommands(otherSubcommands []cli.Command) []cli.Command {
-
 	cmd.Config.ValidateProjectScripts(otherSubcommands)
 
 	if cmd.Config.Scripts == nil {
@@ -77,7 +66,6 @@ func (cmd *Project) GetScriptsAsSubcommands(otherSubcommands []cli.Command) []cl
 			if len(script.Alias) > 0 {
 				command.Aliases = []string{script.Alias}
 			}
-
 			command.Description = command.Description + cmd.ScriptRunHelp(script)
 
 			commands = append(commands, command)
@@ -87,9 +75,9 @@ func (cmd *Project) GetScriptsAsSubcommands(otherSubcommands []cli.Command) []cl
 	return commands
 }
 
-// Return the help for all the scripts.
+// Execute the selected projec script.
 func (cmd *Project) Run(c *cli.Context) error {
-
+	cmd.out.Verbose.Printf("Loaded project configuration from %s", cmd.Config.Path)
 	if cmd.Config.Scripts == nil {
 		cmd.out.Error.Fatal("There are no scripts discovered in: %s", cmd.Config.File)
 	}

--- a/cli/commands/project_config.go
+++ b/cli/commands/project_config.go
@@ -36,7 +36,6 @@ type ProjectConfig struct {
 
 // Create a new ProjectConfig using configured or default locations
 func NewProjectConfig() *ProjectConfig {
-	logger := util.Logger()
 	readyConfig := &ProjectConfig{}
 	projectConfigFile := os.Getenv("RIG_PROJECT_CONFIG_FILE")
 
@@ -47,7 +46,6 @@ func NewProjectConfig() *ProjectConfig {
 	if projectConfigFile != "" {
 		if config, err := NewProjectConfigFromFile(projectConfigFile); err == nil {
 			readyConfig = config
-			logger.Verbose.Printf("Loaded project configuration from %s", readyConfig.Path)
 		}
 	}
 
@@ -75,10 +73,11 @@ func FindProjectConfigFilePath() (string, error) {
 	return "", errors.New("No outrigger configuration file found.")
 }
 
-// Create a new ProjectConfig from the specified file
+// Create a new ProjectConfig from the specified file.
+// @todo do not use the logger here, instead return errors.
+// Use of the logger here initializes it in non-verbose mode.
 func NewProjectConfigFromFile(filename string) (*ProjectConfig, error) {
 	logger := util.Logger()
-
 	filepath, _ := filepath.Abs(filename)
 	config := &ProjectConfig{
 		File: filename,

--- a/cli/commands/project_config.go
+++ b/cli/commands/project_config.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -35,27 +36,43 @@ type ProjectConfig struct {
 
 // Create a new ProjectConfig using configured or default locations
 func NewProjectConfig() *ProjectConfig {
+	logger := util.Logger()
+	readyConfig := &ProjectConfig{}
 	projectConfigFile := os.Getenv("RIG_PROJECT_CONFIG_FILE")
 
-	var discovery []string
 	if projectConfigFile == "" {
-		discovery = make([]string, 2)
-		discovery[0] = "./outrigger.yml"
-		discovery[1] = "./.outrigger.yml"
-	} else {
-		discovery = make([]string, 1)
-		discovery[0] = projectConfigFile
+		projectConfigFile, _ = FindProjectConfigFilePath()
 	}
 
-	readyConfig := &ProjectConfig{}
-	for _, filePath := range discovery {
-		if config, err := NewProjectConfigFromFile(filePath); err == nil {
+	if projectConfigFile != "" {
+		if config, err := NewProjectConfigFromFile(projectConfigFile); err == nil {
 			readyConfig = config
-			break
+			logger.Verbose.Printf("Loaded project configuration from %s", readyConfig.Path)
 		}
 	}
 
 	return readyConfig
+}
+
+// Traverse directory structure looking for an outrigger project config file.
+func FindProjectConfigFilePath() (string, error) {
+	if cwd, err := os.Getwd(); err == nil {
+		var configFilePath string
+		for cwd != "." && cwd != string(filepath.Separator) {
+			for _, filename := range [2]string{"outrigger.yml", ".outrigger.yml"} {
+				configFilePath = filepath.Join(cwd, filename)
+				if _, err := os.Stat(configFilePath); !os.IsNotExist(err) {
+					return configFilePath, nil
+				}
+			}
+
+			cwd = filepath.Dir(cwd)
+		}
+	} else {
+		return "", err
+	}
+
+	return "", errors.New("No outrigger configuration file found.")
 }
 
 // Create a new ProjectConfig from the specified file
@@ -70,7 +87,7 @@ func NewProjectConfigFromFile(filename string) (*ProjectConfig, error) {
 
 	yamlFile, err := ioutil.ReadFile(config.File)
 	if err != nil {
-		logger.Verbose.Printf("No project configuration file found at: %s", config.File)
+		logger.Verbose.Printf("No project configuration file could be read at: %s", config.File)
 		return config, err
 	}
 

--- a/cli/commands/project_sync.go
+++ b/cli/commands/project_sync.go
@@ -72,19 +72,10 @@ func (cmd *ProjectSync) Commands() []cli.Command {
 	return []cli.Command{start, stop}
 }
 
-// Run before all commands to setup core services
-func (cmd *ProjectSync) Before(c *cli.Context) error {
-	if err := cmd.BaseCommand.Before(c); err != nil {
-		return err
-	}
-	cmd.Config = NewProjectConfig()
-	cmd.out.Verbose.Printf("Loaded project configuration from %s", cmd.Config.Path)
-
-	return nil
-}
-
 // Start the unison sync process
 func (cmd *ProjectSync) RunStart(ctx *cli.Context) error {
+	cmd.Config = NewProjectConfig()
+	cmd.out.Verbose.Printf("Loaded project configuration from %s", cmd.Config.Path)
 	volumeName := cmd.GetVolumeName(ctx, cmd.Config)
 
 	switch platform := runtime.GOOS; platform {
@@ -182,6 +173,8 @@ func (cmd *ProjectSync) RunStop(ctx *cli.Context) error {
 		cmd.out.Info.Println("No unison container to stop, using local bind volume")
 		return nil
 	}
+	cmd.Config = NewProjectConfig()
+	cmd.out.Verbose.Printf("Loaded project configuration from %s", cmd.Config.Path)
 
 	volumeName := cmd.GetVolumeName(ctx, cmd.Config)
 	cmd.out.Verbose.Printf("Stopping sync with volume: %s", volumeName)


### PR DESCRIPTION
This adjusts the way project config is loaded by default. It will first check the current working directory... then it will traverse up through the directory structure, much like git looking for a .git directory.

As part of this, I wanted to ensure verbose logging of the location of the loaded file, which led me down the path of investigating #88. I'm not quite sure if I'm not seeing things that this extra initialization does something. Also interesting, the verbose log in cmd.Before that I've added to project_sync.go and project.go is being called twice.

The screenshot illustrates what this does even better:
<img width="1052" alt="recursive-config-discovery" src="https://user-images.githubusercontent.com/283489/31647714-a001b8a0-b2be-11e7-9f15-e9f0c3b1a15d.png">
<sup>In the screenshot, you see the config is loaded from a parent directory of the PWD and executing as though in that parent directory.</sup>

Fix for #87, partial fix for #88.
I envision this being pushed through before the refactoring to get #86 wrapped up.