### PR TITLE
Travis test: rig CLI can execute.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_install: cd cli
 
 script:
   - "../scripts/test-go-fmt.sh"
+  - "go run main.go"
 
 notifications:
   flowdock:


### PR DESCRIPTION
It turns out that Travis is already successfully retrieving dependencies. This addition confirms that rig can be compiled and executed.