### PR TITLE
Switch command logging from yellow to magenta.

### DIFF
--- a/util/shell_exec.go
+++ b/util/shell_exec.go
@@ -114,7 +114,7 @@ func (x Executor) Start() error {
 
 // Log verbosely logs the command.
 func (x Executor) Log(tag string) {
-	color.Set(color.FgYellow)
+	color.Set(color.FgMagenta)
 	Logger().Verbose.Printf("%s: %s", tag, x.ToString())
 	color.Unset()
 }


### PR DESCRIPTION
Here we are, switching from yellow to magenta because warn logs are already yellow.