### PR TITLE
Refinement of new logging API usage.

### DIFF
--- a/commands/command.go
+++ b/commands/command.go
@@ -45,7 +45,8 @@ func (cmd *BaseCommand) Success(message string) error {
 		util.NotifySuccess(cmd.context, message)
 	}
 
-	// If there is an active spinner wrap it up.
+	// If there is an active spinner wrap it up. This is not placed before the logging above so commands can rely on
+	// cmd.Success to set the last spinner status in lieu of an extraneous log entry.
 	cmd.out.NoSpin()
 
 	return nil

--- a/commands/data_backup.go
+++ b/commands/data_backup.go
@@ -70,6 +70,10 @@ func (cmd *DataBackup) Run(c *cli.Context) error {
 		return cmd.Failure("Backup failed", "COMMAND-ERROR", 13)
 	}
 
-	cmd.out.Info("Backup complete: %s", backupFile)
+	cmd.out.Info("Data backup saved to %s", backupFile)
+	// Our final success message provides details on where to find the backup file.
+	// The success notifcation is kept simple by not passing back the filepath.
+	cmd.out.NoSpin()
+
 	return cmd.Success("Data Backup completed")
 }

--- a/commands/data_restore.go
+++ b/commands/data_restore.go
@@ -65,6 +65,5 @@ func (cmd *DataRestore) Run(c *cli.Context) error {
 		return cmd.Failure("Data restore failed", "COMMAND-ERROR", 13)
 	}
 
-	cmd.out.Info("Data restore complete")
-	return cmd.Success("Data Restore was successful")
+	return cmd.Success("Data Restore completed")
 }

--- a/commands/dns.go
+++ b/commands/dns.go
@@ -37,8 +37,6 @@ func (cmd *DNS) Commands() []cli.Command {
 
 // Run executes the `rig dns` command
 func (cmd *DNS) Run(c *cli.Context) error {
-	cmd.out.Info("Configuring DNS")
-
 	if !util.SupportsNativeDocker() && !cmd.machine.IsRunning() {
 		return cmd.Failure(fmt.Sprintf("Machine '%s' is not running.", cmd.machine.Name), "MACHINE-STOPPED", 12)
 	}
@@ -51,6 +49,7 @@ func (cmd *DNS) Run(c *cli.Context) error {
 	if !util.SupportsNativeDocker() {
 		cmd.ConfigureRoutes(cmd.machine)
 	}
+
 	return cmd.Success("DNS Services have been started")
 }
 
@@ -153,7 +152,7 @@ func (cmd *DNS) StartDNS(machine Machine, nameservers string) error {
 		args = append(args, "--nameserver="+server)
 	}
 
-	util.ForceStreamCommand("docker", args...)
+	util.StreamCommand("docker", args...)
 	// Configure the resolvers based on platform
 	var resolverReturn error
 	if util.IsMac() {

--- a/commands/kill.go
+++ b/commands/kill.go
@@ -40,7 +40,7 @@ func (cmd *Kill) Run(c *cli.Context) error {
 		return err
 	}
 
-	cmd.out.Channel.Info.Printf("Killing machine '%s'", cmd.machine.Name)
+	cmd.out.Info("Killing machine '%s'", cmd.machine.Name)
 	util.StreamCommand("docker-machine", "kill", cmd.machine.Name)
 
 	// Ensure the underlying virtualization has stopped
@@ -53,7 +53,7 @@ func (cmd *Kill) Run(c *cli.Context) error {
 	case util.Xhyve:
 		cmd.out.Warning("Add equivalent xhyve kill command.")
 	default:
-		cmd.out.Channel.Warning.Printf("Driver not recognized: %s\n", driver)
+		cmd.out.Warning("Driver not recognized: %s\n", driver)
 	}
 
 	return cmd.Success(fmt.Sprintf("Machine '%s' killed", cmd.machine.Name))

--- a/commands/machine.go
+++ b/commands/machine.go
@@ -22,7 +22,7 @@ type Machine struct {
 
 // Create will generate a new Docker Machine configured according to user specification
 func (m *Machine) Create(driver string, cpuCount string, memSize string, diskSize string) error {
-	m.out.Channel.Info.Printf("Creating a %s machine named '%s' with CPU(%s) MEM(%s) DISK(%s)...", driver, m.Name, cpuCount, memSize, diskSize)
+	m.out.Info("Creating a %s machine named '%s' with CPU(%s) MEM(%s) DISK(%s)...", driver, m.Name, cpuCount, memSize, diskSize)
 
 	boot2dockerURL := "https://github.com/boot2docker/boot2docker/releases/download/v" + util.GetRawCurrentDockerVersion() + "/boot2docker.iso"
 
@@ -72,7 +72,7 @@ func (m *Machine) Create(driver string, cpuCount string, memSize string, diskSiz
 		return fmt.Errorf("error creating machine '%s': %s", m.Name, err)
 	}
 
-	m.out.Channel.Info.Printf("Created docker-machine named '%s'...", m.Name)
+	m.out.Info("Created docker-machine named '%s'...", m.Name)
 	return nil
 }
 
@@ -94,7 +94,7 @@ func (m Machine) CheckXhyveRequirements() error {
 // Start boots the Docker Machine
 func (m Machine) Start() error {
 	if !m.IsRunning() {
-		m.out.Channel.Verbose.Printf("The machine '%s' is not running, starting...", m.Name)
+		m.out.Verbose("The machine '%s' is not running, starting...", m.Name)
 
 		if err := util.StreamCommand("docker-machine", "start", m.Name); err != nil {
 			return fmt.Errorf("error starting machine '%s': %s", m.Name, err)
@@ -127,10 +127,10 @@ func (m Machine) WaitForDev() error {
 	for i := 1; i <= maxTries; i++ {
 		m.SetEnv()
 		if err := util.Command("docker", "ps").Run(); err == nil {
-			m.out.Channel.Verbose.Printf("Machine '%s' has started", m.Name)
+			m.out.Verbose("Machine '%s' has started", m.Name)
 			return nil
 		}
-		m.out.Channel.Warning.Printf("Docker daemon not running! Trying again in %d seconds.  Try %d of %d. \n", sleepSecs, i, maxTries)
+		m.out.Warning("Docker daemon not running! Trying again in %d seconds.  Try %d of %d. \n", sleepSecs, i, maxTries)
 		time.Sleep(time.Duration(sleepSecs) * time.Second)
 	}
 

--- a/commands/project_create.go
+++ b/commands/project_create.go
@@ -83,7 +83,7 @@ func (cmd *ProjectCreate) RunGenerator(ctx *cli.Context, machine Machine, image 
 		if e := util.StreamCommand("docker", "pull", image); e != nil {
 			cmd.out.Error("Project generator docker image failed to update. Using local cache if available: %s", image)
 		} else {
-			cmd.out.Warning("Project generator docker image is up-to-date: %s", image)
+			cmd.out.Info("Project generator docker image is up-to-date: %s", image)
 		}
 	} else if err == nil && ctx.Bool("no-update") {
 		cmd.out.Verbose("Automatic generator image update suppressed by --no-update option.")

--- a/commands/prune.go
+++ b/commands/prune.go
@@ -26,10 +26,10 @@ func (cmd *Prune) Commands() []cli.Command {
 
 // Run executes the `rig prune` command
 func (cmd *Prune) Run(c *cli.Context) error {
-	cmd.out.Info("Cleaning up Docker images and containers...")
+	cmd.out.Spin("Cleaning up unused Docker resources...")
 	if exitCode := util.PassthruCommand(exec.Command("docker", "system", "prune", "--all", "--volumes")); exitCode != 0 {
 		return cmd.Failure("Failure pruning Docker resources.", "COMMAND-ERROR", 13)
 	}
-
+	cmd.out.Info("Unused Docker images, containers, volumes, and networks cleaned up.")
 	return cmd.Success("")
 }

--- a/commands/remove.go
+++ b/commands/remove.go
@@ -47,7 +47,8 @@ func (cmd *Remove) Run(c *cli.Context) error {
 		cmd.out.Warning("Run 'rig data-backup' if you want to save your /data volume.")
 
 		if !util.AskYesNo("Are you sure you want to remove '" + cmd.machine.Name + "'") {
-			return cmd.Success("Remove was aborted")
+			cmd.out.Info("Remove was aborted")
+			return cmd.Success("")
 		}
 	}
 
@@ -63,6 +64,6 @@ func (cmd *Remove) Run(c *cli.Context) error {
 		return cmd.Failure(err.Error(), "MACHINE-REMOVE-FAILED", 12)
 	}
 
-	cmd.out.Info("Failed to remove the docker Virtual Machine")
+	cmd.out.Info("Removed the Docker Virtual Machine")
 	return cmd.Success(fmt.Sprintf("Machine '%s' removed", cmd.machine.Name))
 }

--- a/commands/restart.go
+++ b/commands/restart.go
@@ -29,9 +29,9 @@ func (cmd *Restart) Commands() []cli.Command {
 func (cmd *Restart) Run(c *cli.Context) error {
 	if util.SupportsNativeDocker() || cmd.machine.Exists() {
 		if util.SupportsNativeDocker() {
-			cmd.out.Info("Restarting Outrigger services")
+			cmd.out.Spin("Restarting Outrigger services")
 		} else {
-			cmd.out.Channel.Info.Printf("Restarting Outrigger machine '%s' and services", cmd.machine.Name)
+			cmd.out.Spin(fmt.Sprintf("Restarting Outrigger machine '%s' and services", cmd.machine.Name))
 		}
 
 		stop := Stop{cmd.BaseCommand}

--- a/commands/status.go
+++ b/commands/status.go
@@ -28,7 +28,8 @@ func (cmd *Status) Commands() []cli.Command {
 // Run executes the `rig status` command
 func (cmd *Status) Run(c *cli.Context) error {
 	if util.SupportsNativeDocker() {
-		return cmd.Success("Status is not needed on Linux")
+		cmd.out.Info("Status is not needed on Linux")
+		return cmd.Success("")
 	}
 
 	if !cmd.machine.Exists() {

--- a/commands/upgrade.go
+++ b/commands/upgrade.go
@@ -62,7 +62,7 @@ func (cmd *Upgrade) Run(c *cli.Context) error {
 		return cmd.Success(fmt.Sprintf("Machine '%s' has the same Docker version (%s) as your local Docker binary (%s). There is nothing to upgrade. If you wish to upgrade you'll need to install a newer version of the Docker binary before running the upgrade command.", cmd.machine.Name, machineDockerVersion, currentDockerVersion))
 	}
 
-	cmd.out.Channel.Info.Printf("Backing up to prepare for upgrade...")
+	cmd.out.Info("Backing up to prepare for upgrade...")
 	backup := &DataBackup{cmd.BaseCommand}
 	if err := backup.Run(c); err != nil {
 		return err


### PR DESCRIPTION
Here is another batch of changes related to the logging API.

* Use the main logging API instead of the sidestepping when it's not needed.
* Found a few places to tweak how the spinner is used.
* Found a couple negated log messages.
* String tweaks for clarity/accuracy.

This was done with a line-by-line audit of the code, I think that's about it for improvements of the messaging without live testing.