### PR TITLE
Developer Testing Commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,12 @@ Here are a few conventions:
   return cmd.Failure(message)
   ```
 
+## Developer Testing Commands
+
+You can use `rig dev:win` or `rig dev:fail` as no-op commands to observe the
+effects of a success or failure without external dependencies on the local
+environment or side effects from "real" commands doing their job.
+
 ## Development Environment Setup
 
 ### Developing with Docker

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -65,6 +65,7 @@ func main() {
 	app.Commands = append(app.Commands, (&commands.Remove{}).Commands()...)
 	app.Commands = append(app.Commands, (&commands.Project{}).Commands()...)
 	app.Commands = append(app.Commands, (&commands.Doctor{}).Commands()...)
+	app.Commands = append(app.Commands, (&commands.Dev{}).Commands()...)
 
 	app.Run(os.Args)
 }

--- a/commands/command.go
+++ b/commands/command.go
@@ -39,23 +39,28 @@ func (cmd *BaseCommand) Before(c *cli.Context) error {
 
 // Success encapsulates the functionality for reporting command success
 func (cmd *BaseCommand) Success(message string) error {
-	// Handle success messaging.
+	// Handle success messaging. If the spinner is running or not, this will
+	// output accordingly and issue a notification.
 	if message != "" {
 		cmd.out.Info(message)
 		util.NotifySuccess(cmd.context, message)
+	} else {
+		// If there is an active spinner wrap it up. This is not placed before the
+		// logging above so commands can rely on cmd.Success to set the last spinner
+		// status in lieu of an extraneous log entry.
+		cmd.out.NoSpin()
 	}
-
-	// If there is an active spinner wrap it up. This is not placed before the logging above so commands can rely on
-	// cmd.Success to set the last spinner status in lieu of an extraneous log entry.
-	cmd.out.NoSpin()
 
 	return nil
 }
 
 // Failure encapsulates the functionality for reporting command failure
 func (cmd *BaseCommand) Failure(message string, errorName string, exitCode int) error {
-	// Make sure any running spinner halts.
-	cmd.out.NoSpin()
+	// If the spinner is running, output something to get closure and shut it down.
+	if cmd.out.Spinning {
+		cmd.out.Error(message)
+	}
+
 	// Handle error messaging.
 	util.NotifyError(cmd.context, message)
 	// Print expanded troubleshooting guidance.

--- a/commands/dev.go
+++ b/commands/dev.go
@@ -1,0 +1,50 @@
+package commands
+
+import (
+	"time"
+
+	"github.com/urfave/cli"
+)
+
+// Dev is the command for setting docker config to talk to a Docker Machine
+type Dev struct {
+	BaseCommand
+}
+
+// Commands returns the operations supported by this command
+func (cmd *Dev) Commands() []cli.Command {
+	return []cli.Command{
+		{
+			Name:   "dev:win",
+			Usage:  "A no-op command that will always succeed.",
+			Before: cmd.Before,
+			Action: cmd.RunSucceed,
+			Hidden: true,
+		},
+		{
+			Name:   "dev:fail",
+			Usage:  "A no-op command that will always fail.",
+			Before: cmd.Before,
+			Action: cmd.RunFail,
+			Hidden: true,
+		},
+	}
+}
+
+// RunSucceed executes the `rig dev:succeed` command
+func (cmd *Dev) RunSucceed(c *cli.Context) error {
+	cmd.out.Spin("Think positive...")
+	time.Sleep(3 * time.Second)
+	cmd.out.Info("We've got it.")
+	return cmd.Success("Positively successful!")
+}
+
+// RunFail executes the `rig dev:fail` command
+func (cmd *Dev) RunFail(c *cli.Context) error {
+	cmd.out.Spin("Abandon all hope...")
+	time.Sleep(3 * time.Second)
+	cmd.out.Warning("Hope slipping...")
+	cmd.out.Spin("Is the sky painted black?")
+	time.Sleep(3 * time.Second)
+	return cmd.Failure("Hope abandoned :(", "ABANDON-HOPE", 418)
+}

--- a/util/help.go
+++ b/util/help.go
@@ -28,6 +28,8 @@ func PrintDebugHelp(message, errorName string, exitCode int) {
 		codeMessage = "environmental"
 	case 13:
 		codeMessage = "external/upstream command"
+	case 418:
+		codeMessage = "rig developer test command"
 	default:
 		codeMessage = "general"
 	}


### PR DESCRIPTION
Adds a couple simple developer testing commands. Very simple, guaranteed success/error state, that allows looking at how the spinner, logging, and notification works. We might add some more interaction cases to these in the future to facilitate manual/functional testing.

The hidden attribute means they are not displayed in help, and are only usable if you know they are there.