### PR TITLE
Upgraded travis config to go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os: linux
 
 language: go
 go:
-  - 1.10
+  - "1.10"
   - tip
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     - go: tip
 
 install:
-  - "go get -u github.com/golang/dep/..."
+  - "curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh"
   - "go get -u github.com/alecthomas/gometalinter"
   - "gometalinter --install --update"
   - "dep ensure"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os: linux
 
 language: go
 go:
-  - 1.9
+  - 1.10
   - tip
 
 matrix:
@@ -20,7 +20,7 @@ install:
 
 script:
   - "scripts/test-go-fmt.sh"
-  - "gometalinter --vendor --config=gometalinter.json ./..."
+  - "gometalinter --vendor --deadline=60s --config=gometalinter.json ./..."
   - "go run cmd/main.go"
 
 notifications:


### PR DESCRIPTION
Latest PR failed a gometalinter test with deadline time limit.  Our builder moved to go 1.10 so we need that too.