### PR TITLE
Project Doctor

### DIFF
--- a/commands/project.go
+++ b/commands/project.go
@@ -32,6 +32,9 @@ func (cmd *Project) Commands() []cli.Command {
 	sync := ProjectSync{}
 	command.Subcommands = append(command.Subcommands, sync.Commands()...)
 
+	doctor := ProjectDoctor{}
+	command.Subcommands = append(command.Subcommands, doctor.Commands()...)
+
 	if subcommands := cmd.GetScriptsAsSubcommands(command.Subcommands); subcommands != nil {
 		command.Subcommands = append(command.Subcommands, subcommands...)
 	}
@@ -80,13 +83,13 @@ func (cmd *Project) Run(c *cli.Context) error {
 	}
 
 	key := strings.TrimPrefix(c.Command.Name, "run:")
-        if script, ok := cmd.Config.Scripts[key]; !ok {
+	if script, ok := cmd.Config.Scripts[key]; !ok {
 		return cmd.Failure(fmt.Sprintf("Unrecognized script '%s'", key), "SCRIPT-NOT-FOUND", 12)
-        } else {
-                eval := ProjectEval{cmd.out, cmd.Config}
-                if exitCode := eval.ProjectScriptRun(script, c.Args()); exitCode != 0 {
-                        return cmd.Failure(fmt.Sprintf("Failure running project script '%s'", key), "COMMAND-ERROR", exitCode)
-                }
+	} else {
+		eval := ProjectEval{cmd.out, cmd.Config}
+		if exitCode := eval.ProjectScriptRun(script, c.Args()); exitCode != 0 {
+			return cmd.Failure(fmt.Sprintf("Failure running project script '%s'", key), "COMMAND-ERROR", exitCode)
+		}
 	}
 
 	return cmd.Success("")

--- a/commands/project_config.go
+++ b/commands/project_config.go
@@ -14,6 +14,7 @@ import (
 
 // ProjectScript is the struct for project defined commands
 type ProjectScript struct {
+        Id          string
 	Alias       string
 	Description string
 	Run         []string
@@ -79,6 +80,7 @@ func FindProjectConfigFilePath() (string, error) {
 // NewProjectConfigFromFile creates a new ProjectConfig from the specified file.
 // @todo do not use the logger here, instead return errors.
 // Use of the logger here initializes it in non-verbose mode.
+// nolint: gocyclo
 func NewProjectConfigFromFile(filename string) (*ProjectConfig, error) {
 	logger := util.Logger()
 	filepath, _ := filepath.Abs(filename)
@@ -108,6 +110,7 @@ func NewProjectConfigFromFile(filename string) (*ProjectConfig, error) {
 	for id, script := range config.Scripts {
 		if script != nil && script.Description == "" {
 			config.Scripts[id].Description = fmt.Sprintf("Configured operation for '%s'", id)
+                        config.Scripts[id].Id = id
 		}
 	}
 

--- a/commands/project_config.go
+++ b/commands/project_config.go
@@ -14,7 +14,7 @@ import (
 
 // ProjectScript is the struct for project defined commands
 type ProjectScript struct {
-        Id          string
+	Id          string
 	Alias       string
 	Description string
 	Run         []string
@@ -28,9 +28,9 @@ type Sync struct {
 
 // ProjectConfig is the struct for the outrigger.yml file
 type ProjectConfig struct {
-	File string
-	Path string
-
+	File      string
+	Path      string
+	Doctor    map[string]*Condition
 	Scripts   map[string]*ProjectScript
 	Sync      *Sync
 	Namespace string
@@ -110,7 +110,20 @@ func NewProjectConfigFromFile(filename string) (*ProjectConfig, error) {
 	for id, script := range config.Scripts {
 		if script != nil && script.Description == "" {
 			config.Scripts[id].Description = fmt.Sprintf("Configured operation for '%s'", id)
-                        config.Scripts[id].Id = id
+			config.Scripts[id].Id = id
+		}
+	}
+
+	for id, condition := range config.Doctor {
+		if condition != nil {
+			config.Doctor[id].Id = id
+			if config.Doctor[id].Severity != "" {
+				if _, ok := util.IndexOfString(SeverityList(), config.Doctor[id].Severity); !ok {
+					logger.Channel.Error.Fatalf("Invalid severity (%s) for doctor condition (%s) in %s", config.Doctor[id].Severity, id, filename)
+				}
+			} else {
+				config.Doctor[id].Severity = "info"
+			}
 		}
 	}
 

--- a/commands/project_doctor.go
+++ b/commands/project_doctor.go
@@ -1,0 +1,215 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/urfave/cli"
+)
+
+type ProjectDoctor struct {
+	BaseCommand
+	Config *ProjectConfig
+}
+
+// @TODO add an error tier for fatal, wherein analysis should be halted.
+const (
+	ConditionSeverityINFO    string = "info"
+	ConditionSeverityWARNING string = "warning"
+	ConditionSeverityERROR   string = "error"
+)
+
+type Condition struct {
+	Id           string
+	Name         string
+	Test         []string
+	Diagnosis    string
+	Prescription string
+	Severity     string
+}
+
+type ConditionCollection map[string]*Condition
+
+func (cmd *ProjectDoctor) Commands() []cli.Command {
+	cmd.Config = NewProjectConfig()
+
+	diagnose := cli.Command{
+		Name:        "doctor:diagnose",
+		Aliases:     []string{"doctor"},
+		Usage:       "Run to evaluate project-level environment problems.",
+		Description: "This command validates known problems with the project environment. The rules can be extended via the 'doctor' section of the project configuration.",
+		Before:      cmd.Before,
+		Action:      cmd.RunAnalysis,
+	}
+
+	compendium := cli.Command{
+		Name:        "doctor:conditions",
+		Aliases:     []string{"doctor:list"},
+		Usage:       "Learn all the rules applied by the doctor:diagnose command.",
+		Description: "Display all the conditions for which the doctor:diagnose command will check.",
+		Before:      cmd.Before,
+		Action:      cmd.RunCompendium,
+	}
+
+	return []cli.Command{diagnose, compendium}
+}
+
+// RunAnalysis controls the doctor/diagnosis process.
+func (cmd *ProjectDoctor) RunAnalysis(ctx *cli.Context) error {
+	compendium, _ := cmd.GetConditionCollection()
+	if err := cmd.AnalyzeConditionList(compendium); err != nil {
+		// Directly returning the framework error to skip the expanded help.
+		// A failing state is self-descriptive.
+		return cli.NewExitError(fmt.Sprintf("%v", err), 1)
+	}
+
+	return nil
+}
+
+// RunCompendium lists all conditions to be checked in the analysis.
+func (cmd *ProjectDoctor) RunCompendium(ctx *cli.Context) error {
+	compendium, _ := cmd.GetConditionCollection()
+	cmd.out.Info("There are %d conditions in the repertoire.", len(compendium))
+	fmt.Println(compendium)
+
+	return nil
+}
+
+// AnalyzeConditionList checks each registered condition against environment state.
+func (cmd *ProjectDoctor) AnalyzeConditionList(conditions ConditionCollection) error {
+	var returnVal error
+
+	failing := ConditionCollection{}
+	for _, condition := range conditions {
+		cmd.out.Spin(fmt.Sprintf("Examining project environment for %s", condition.Name))
+		if found := cmd.Analyze(condition); !found {
+			cmd.out.Info("Not Affected by: %s [%s]", condition.Name, condition.Id)
+		} else {
+			switch condition.Severity {
+			case ConditionSeverityWARNING:
+				cmd.out.Warning("Condition Detected: %s [%s]", condition.Name, condition.Id)
+				failing[condition.Id] = condition
+				break
+			case ConditionSeverityERROR:
+				cmd.out.Error("Condition Detected: %s [%s]", condition.Name, condition.Id)
+				failing[condition.Id] = condition
+				if returnVal == nil {
+					returnVal = errors.New("Diagnosis found at least one failing condition.")
+				}
+				break
+			default:
+				cmd.out.Info("Condition Detected: %s [%s]", condition.Name, condition.Id)
+			}
+		}
+	}
+
+	if len(failing) > 0 {
+		color.Red("\nThere were %d problems identified out of %d checked.\n", len(failing), len(conditions))
+		fmt.Println(failing)
+	}
+
+	return returnVal
+}
+
+// GetConditionCollection assembles a list of all conditions.
+func (cmd *ProjectDoctor) GetConditionCollection() (ConditionCollection, error) {
+	conditions := cmd.Config.Doctor
+
+	// @TODO instead of defining these here, we need a macro language (go template?)
+	// that understands how to get the sync name, check if containers exist (maybe)
+	// and so on. That should be in a separate file.
+	if runtime.GOOS != "linux" {
+		eval := ProjectEval{cmd.out, cmd.Config}
+		sync := ProjectSync{}
+		syncName := sync.GetVolumeName(cmd.Config, eval.GetWorkingDirectory())
+
+		// @todo we should have a way to determine if the project wants to use sync.
+		item1 := &Condition{
+			Id:           "sync-container-not-running",
+			Name:         "Sync Container Not Working",
+			Test:         []string{fmt.Sprintf("$(id=$(docker container ps -q --filter 'name=%s'); docker top $id &>/dev/null)", syncName)},
+			Diagnosis:    "The Sync container for this project is not available.",
+			Prescription: "Run 'rig project sync:start' before beginning work. This command may be included in other project-specific tasks.",
+			Severity:     ConditionSeverityWARNING,
+		}
+		if _, ok := conditions["sync-container-not-running"]; !ok {
+			conditions["sync-container-not-running"] = item1
+		}
+
+		item2 := &Condition{
+			Id:           "sync-volume-missing",
+			Name:         "Sync Volume is Missing",
+			Test:         []string{fmt.Sprintf("$(id=$(docker container ps -q --filter 'name=%s'); docker top $id &>/dev/null)", syncName)},
+			Diagnosis:    "The Sync volume for this project is missing.",
+			Prescription: "Run 'rig project sync:start' before beginning work. This command may be included in other project-specific tasks.",
+			Severity:     ConditionSeverityWARNING,
+		}
+		if _, ok := conditions["sync-volume-missing"]; !ok {
+			conditions["sync-volume-missing"] = item2
+		}
+	}
+
+	return conditions, nil
+}
+
+// Analyze if a given condition criteria is met.
+func (cmd *ProjectDoctor) Analyze(c *Condition) bool {
+	eval := ProjectEval{cmd.out, cmd.Config}
+	script := &ProjectScript{c.Id, "", c.Name, c.Test}
+
+	if _, exitCode, err := eval.ProjectScriptResult(script, []string{}); err != nil {
+		cmd.out.Verbose("Condition '%s' analysis failed: (%d)", c.Id, exitCode)
+		cmd.out.Verbose("Error: %s", err.Error())
+		return true
+	}
+
+	return false
+}
+
+// String converts a ConditionCollection to a string.
+// @TODO use a good string concatenation technique, unlike this.
+func (cc ConditionCollection) String() string {
+	str := ""
+	for _, condition := range cc {
+		str = fmt.Sprintf(fmt.Sprintf("%s\n%s\n", str, condition))
+	}
+	return fmt.Sprintf(fmt.Sprintf("%s\n", str))
+}
+
+// String converts a Condition to a string.
+func (c Condition) String() string {
+	return fmt.Sprintf("%s (%s)\n\tDESCRIPTION: %s\n\tSOLUTION: %s\n\t[%s]",
+		headline(c.Name),
+		severityFormat(c.Severity),
+		c.Diagnosis,
+		c.Prescription,
+		c.Id)
+}
+
+func headline(value string) string {
+	h := color.New(color.Bold, color.Underline).SprintFunc()
+	return h(value)
+}
+
+func severityFormat(severity string) string {
+
+	switch severity {
+	case ConditionSeverityWARNING:
+		yellow := color.New(color.FgYellow).SprintFunc()
+		return yellow(strings.ToUpper(severity))
+	case ConditionSeverityERROR:
+		red := color.New(color.FgRed).SprintFunc()
+		return red(strings.ToUpper(severity))
+	}
+
+	cyan := color.New(color.FgCyan).SprintFunc()
+	return cyan(strings.ToUpper(severity))
+}
+
+// SeverityList supplies the valid conditions as an array.
+func SeverityList() []string {
+	return []string{ConditionSeverityINFO, ConditionSeverityWARNING, ConditionSeverityERROR}
+}

--- a/commands/project_eval.go
+++ b/commands/project_eval.go
@@ -47,8 +47,10 @@ func (p *ProjectEval) GetCommand(steps, extra []string, workingDirectory string)
 
 	var command *exec.Cmd
 	if util.IsWindows() {
+		/* #nosec */
 		command = exec.Command("cmd", "/c", scriptCommands)
 	} else {
+		/* #nosec */
 		command = exec.Command("sh", "-c", scriptCommands)
 	}
 	command.Dir = workingDirectory

--- a/commands/project_eval.go
+++ b/commands/project_eval.go
@@ -1,0 +1,82 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/phase2/rig/util"
+)
+
+type ProjectEval struct {
+	out    *util.RigLogger
+	config *ProjectConfig
+}
+
+// ProjectScriptRun takes a ProjectScript configuration and executes it per
+// the definition of the project script and bonus arguments from the extra parameter.
+// Commands are run from the directory context of the project if available.
+// Use ProjectScriptRun to run a comman for potential user interaction.
+func (p *ProjectEval) ProjectScriptRun(script *ProjectScript, extra []string) int {
+	p.out.Verbose("Initializing project script '%s': %s", script.Id, script.Description)
+	p.addCommandPath()
+	dir := p.GetWorkingDirectory()
+	shellCmd := p.GetCommand(script.Run, extra, dir)
+	p.out.Verbose("Evaluating Script '%s'", script.Id)
+	return util.PassthruCommand(shellCmd)
+}
+
+// ProjectScriptResult matches ProjectScriptRun, but returns the data from the
+// command execution instead of "streaming" the result to the terminal.
+func (p *ProjectEval) ProjectScriptResult(script *ProjectScript, extra []string) (string, int, error) {
+	p.out.Verbose("Initializing project script '%s': %s", script.Id, script.Description)
+	p.addCommandPath()
+	dir := p.GetWorkingDirectory()
+	shellCmd := p.GetCommand(script.Run, extra, dir)
+	p.out.Verbose("Evaluating Script '%s'", script.Id)
+	return util.CaptureCommand(shellCmd)
+}
+
+// GetCommand constructs a command to execute a configured script.
+// @see https://github.com/medhoover/gom/blob/staging/config/command.go
+func (p *ProjectEval) GetCommand(steps, extra []string, workingDirectory string) *exec.Cmd {
+	// Concat the commands together adding the args to this command as args to the last step
+	scriptCommands := strings.Join(steps, p.getCommandSeparator()) + " " + strings.Join(extra, " ")
+
+	var command *exec.Cmd
+	if util.IsWindows() {
+		command = exec.Command("cmd", "/c", scriptCommands)
+	} else {
+		command = exec.Command("sh", "-c", scriptCommands)
+	}
+	command.Dir = workingDirectory
+
+	return command
+}
+
+// GetWorkingDirectory retrieves the working directory for project commands.
+func (p *ProjectEval) GetWorkingDirectory() string {
+	return filepath.Dir(p.config.Path)
+}
+
+// getCommandSeparator returns the command separator based on platform.
+func (p *ProjectEval) getCommandSeparator() string {
+	if util.IsWindows() {
+		return " & "
+	}
+
+	return " && "
+}
+
+// addCommandPath overrides the PATH environment variable for further shell executions.
+// This is used on POSIX systems for lookup of scripts.
+func (p *ProjectEval) addCommandPath() {
+	binDir := p.config.Bin
+	if binDir != "" {
+		p.out.Verbose("Adding project bin directory to $PATH: %s", binDir)
+		path := os.Getenv("PATH")
+		os.Setenv("PATH", fmt.Sprintf("%s%c%s", binDir, os.PathListSeparator, path))
+	}
+}

--- a/examples/outrigger.example.yml
+++ b/examples/outrigger.example.yml
@@ -89,3 +89,34 @@ sync:
     - "Path vendor/"
     - "Path build/logs"
     - "Regex build/backups/.*\\.sql"
+
+# Configuration of doctor behavior.
+doctor:
+  automatic-success:
+    name: Always Passing
+    diagnosis: Nothing will ever be wrong.
+    prescription: No action will need to be taken.
+    test:
+      - exit 0
+    severity: info
+  automatic-fyi:
+    name: FYI
+    diagnosis: We found a thing but it's ok.
+    prescription: No action needs to be taken.
+    test:
+      - exit 1
+    severity: info
+  automatic-warning:
+    name: Always Warning
+    diagnosis: This always concerns us.
+    prescription: Edit your outrigger.yml.
+    test:
+      - exit 1
+    severity: warning
+  automatic-failure:
+    name: Always Failing
+    diagnosis: Everything is always wrong.
+    prescription: Edit your outrigger.yml.
+    test:
+      - exit 1
+    severity: error


### PR DESCRIPTION
Here's a reboot on the project doctor work. This is based on #157 and should be reviewed after that.

With some tweaks to the built-in conditions we could merge this as-is, but there are a few things I'd like to address:

### Uncomfortable Things

* Extract the two defined conditions into working examples. I found it really difficult to parameterize for container running checks, but if we go with the sync container name in the outrigger.example.yml it will work fine.

### Future Enhancements

* Add a `rig project sync:name` command to supply the sync volume and sync container name.
* Whether as rig commands or as gotemplate macros, it's really tricky to script good checks for whether container is running. I'd like to facilitate that so projects can add checks that their required services are live.
* Integrate with a future `rig project sync:doctor` command which verifies the health of the sync process. (I'm planning to tackle that to split the current checking rig project sync does as part of setup into a separately callable API method and command.)
* Concurrently execution doctor checks. This requires some stuff:
  * Addressing timeouts
  * Not outputting the results of the condition execution even in verbose mode as interleaving will be too confusing.
  * Potentially adding something like `rig project doctor --analyze=conditionId` to support testing that a condition behaves in isolation.