### PR TITLE
Activate power user mode when running rig project scripts.

### DIFF
--- a/commands/project.go
+++ b/commands/project.go
@@ -94,6 +94,7 @@ func (cmd *Project) Run(c *cli.Context) error {
 
 		shellCmd := cmd.GetCommand(scriptCommands)
 		shellCmd.Dir = dir
+		shellCmd.Env = append(os.Environ(), "RIG_POWER_USER_MODE=1")
 		cmd.out.Verbose("Script execution - Working Directory: %s", dir)
 
 		cmd.out.Verbose("Executing '%s' as '%s'", key, scriptCommands)


### PR DESCRIPTION
This prevents the recursion of getting one shouty error per rig project run:* instance in a chain of commands.

Fixes #161 

Needs to be ported into #157