### PR TITLE
dep ensure --update to pick up a new gospinner and other things

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -16,14 +16,14 @@
 [[projects]]
   name = "github.com/fatih/color"
   packages = ["."]
-  revision = "507f6050b8568533fb3f5504de8e5205fa62a114"
-  version = "v1.6.0"
+  revision = "5b77d2a35fb0ede96d138fc9a99f5c9b6aef11b4"
+  version = "v1.7.0"
 
 [[projects]]
   branch = "master"
   name = "github.com/hashicorp/go-version"
   packages = ["."]
-  revision = "4fe82ae3040f80a03d04d2cccb5606a626b8e1ee"
+  revision = "23480c0665776210b5fbbac6eaaee40e3e6a96b7"
 
 [[projects]]
   branch = "master"
@@ -58,8 +58,8 @@
 [[projects]]
   name = "github.com/slok/gospinner"
   packages = ["."]
-  revision = "9ad9fd160041ce6bfb531a55930573fe4c24042d"
-  version = "v0.1.0"
+  revision = "ba1a8734583eeaad4b0dbb77ba5aeee0a8f8ea68"
+  version = "v0.1.1"
 
 [[projects]]
   name = "github.com/urfave/cli"
@@ -71,7 +71,7 @@
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix"]
-  revision = "f6cff0780e542efa0c8e864dc8fa522808f6a598"
+  revision = "fc8bd948cf46f9c7af0f07d34151ce25fe90e477"
 
 [[projects]]
   branch = "v1"
@@ -82,8 +82,8 @@
 [[projects]]
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "7f97868eec74b32b0982dd158a51a446d1da7eb5"
-  version = "v2.1.1"
+  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
+  version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -88,6 +88,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "37871abf94f116d8e8a59b2237a112eaaa983208b2c3131fe761abd7df238104"
+  inputs-digest = "a4f0d12dce32fcc984db18fd0bb1d508617b6bfd3bbe601881e54cfb1954799d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,7 +27,7 @@
 
 [[constraint]]
   name = "github.com/fatih/color"
-  version = "1.5.0"
+  version = "1.7.0"
 
 [[constraint]]
   name = "github.com/mattn/go-isatty"
@@ -55,5 +55,4 @@
 
 [[constraint]]
   name = "github.com/slok/gospinner"
-  version = "0.1.0"
-
+  version = "0.1.1"


### PR DESCRIPTION
gospinner has a new release tag, to address https://github.com/phase2/rig/issues/160.  Did a `dep ensure --update` and picked up that and a few other changes.  This should be part of the next RC so we can get some testing done.